### PR TITLE
Add felinid accent 02 05 2025

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -912,6 +912,7 @@ public sealed partial class AdminVerbSystem
                 EnsureComp<FrenchAccentComponent>(args.Target);
                 EnsureComp<GermanAccentComponent>(args.Target);
                 EnsureComp<LizardAccentComponent>(args.Target);
+                EnsureComp<FelinidAccentComponent>(args.Target);
                 EnsureComp<MobsterAccentComponent>(args.Target);
                 EnsureComp<MothAccentComponent>(args.Target);
                 EnsureComp<OwOAccentComponent>(args.Target);

--- a/Content.Server/Speech/Components/FelinidAccentComponent.cs
+++ b/Content.Server/Speech/Components/FelinidAccentComponent.cs
@@ -1,0 +1,10 @@
+﻿namespace Content.Server.Speech.Components;
+
+/// <summary>
+///     Nyaw!
+/// </summary>
+[RegisterComponent]
+public sealed partial class FelinidAccentComponent : Component
+{
+
+}

--- a/Content.Server/Speech/EntitySystems/FelinidAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FelinidAccentSystem.cs
@@ -24,11 +24,31 @@ public sealed class FelinidAccentSystem : EntitySystem
     {
         var msg = message;
         var ending = "";
+        char last_letter = '.';
+        int i = 1;
+        while(i < msg.Length)
+            {
+                if(char.IsLetter(msg[^i]))
+                {
+                    last_letter = msg[^i];
+                    break;
+                }
+                i++;
+            }
         if(message.Length > 5)
         {
-            if(_random.Prob(0.2f))
+            if(_random.Prob(0.1f))
             {
-                int choice = _random.Next(5);
+                int choice = 0;
+                if(!string.IsNullOrEmpty(msg) && char.IsUpper(last_letter))
+                {
+                    choice = _random.Next(5);
+                }
+                else
+                {
+                    choice = _random.Next(7);
+                }
+
 
                 switch(choice)
                 {
@@ -47,22 +67,17 @@ public sealed class FelinidAccentSystem : EntitySystem
                     case 4:
                         ending =  " -ня";
                         break;
-
+                    case 5:
+                        ending = " -пурр";
+                        break;
+                    case 6:
+                        ending = " -мурр";
+                        break;
                 }
 
             }
         }
-        char last_letter = '.';
-        int i = 1;
-        while(i < msg.Length)
-            {
-                if(char.IsLetter(msg[^i]))
-                {
-                    last_letter = msg[^i];
-                    break;
-                }
-                i++;
-            }
+
         if (!string.IsNullOrEmpty(msg) && char.IsUpper(last_letter))
         {
             ending = ending.ToUpper();

--- a/Content.Server/Speech/EntitySystems/FelinidAccentSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FelinidAccentSystem.cs
@@ -1,0 +1,88 @@
+﻿using System.Text.RegularExpressions;
+using Content.Server.Speech.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server.Speech.EntitySystems;
+
+public sealed class FelinidAccentSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    private static readonly Regex RegexLowerMa = new("ма+");
+    private static readonly Regex RegexUpperMa = new("МА+");
+    private static readonly Regex RegexLowerNa = new("на+");
+    private static readonly Regex RegexUpperNa = new("НА+");
+    private static readonly Regex RegexLowerNe = new("не+");
+    private static readonly Regex RegexUpperNe = new("НЕ+");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FelinidAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    public string AddEndingNyaw(string message)
+    {
+        var msg = message;
+        var ending = "";
+        if(message.Length > 5)
+        {
+            if(_random.Prob(0.2f))
+            {
+                int choice = _random.Next(5);
+
+                switch(choice)
+                {
+                    case 0:
+                        ending =" -няв";
+                        break;
+                    case 1:
+                        ending = " -мяв";
+                        break;
+                    case 2:
+                        ending = " -мав";
+                        break;
+                    case 3:
+                        ending =  " -мя";
+                        break;
+                    case 4:
+                        ending =  " -ня";
+                        break;
+
+                }
+
+            }
+        }
+        char last_letter = '.';
+        int i = 1;
+        while(i < msg.Length)
+            {
+                if(char.IsLetter(msg[^i]))
+                {
+                    last_letter = msg[^i];
+                    break;
+                }
+                i++;
+            }
+        if (!string.IsNullOrEmpty(msg) && char.IsUpper(last_letter))
+        {
+            ending = ending.ToUpper();
+        }
+
+        return msg + ending;
+    }
+
+    private void OnAccent(EntityUid uid, FelinidAccentComponent component, AccentGetEvent args)
+    {
+        var message = args.Message;
+
+        message = RegexLowerMa.Replace(message, "мя");
+        message = RegexUpperMa.Replace(message, "МЯ");
+        message = RegexLowerNa.Replace(message, "ня");
+        message = RegexUpperNa.Replace(message, "НЯ");
+        message = RegexLowerNe.Replace(message, "ня");
+        message = RegexUpperNe.Replace(message, "НЯ");
+
+
+        args.Message = AddEndingNyaw(message);
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -39,6 +39,7 @@
   - FrenchAccent
   - GermanAccent
   - LizardAccent
+  - FelinidAccent
   - MobsterAccent
   - MonkeyAccent
   - MothAccent

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/felinid.yml
@@ -17,6 +17,7 @@
       Male: RMCMaleFelinid
       Unsexed: RMCUnisexFelinid
       Female: RMCFemaleFelinid
+  - type: FelinidAccent
   - type: Speech
     allowedEmotes: ['Hiss', 'Meow', 'Mew', 'Growl', 'Purr']
 

--- a/Resources/Prototypes/_RMC14/Traits/accents.yml
+++ b/Resources/Prototypes/_RMC14/Traits/accents.yml
@@ -57,6 +57,7 @@
     removes:
     - type: LizardAccent
     - type: MothAccent
+    - type: FelinidAccent
     - type: ReplacementAccent
       accent: dwarf
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added new species accent - FelinidAccent.
- Sorry for the shitcode!

## Why / Balance
- It is cool. -NYAW

## Technical details
- The FelinidAccent is based on LizardAccent so it has the same pack of files (FelinidAccentSystem.cs, FelinidAccentComponent.cs) AND the same files where it needed FelinidAccent was quoted (AdminVerbSystem.Smites.cs, accents.yml, felinid.yml, clone.yml (yes, even this thing even we dont use it and it is not in _RMC14)
- Basically, the FelinidAccent changes "ма", "на", "не" into "мя", "ня" and "ня" (yes, "не" to "ня") and with 10% chance (basically same as umlauts at GermanAccent) adds  " -мав", " -няв", " -ня", " -мя", " -пурр" and " -мурр" to the end of the message. The " -пурр" and " -мурр" are only added if the message is not upper (so the person is screaming) adding more sense to it. 
- You absolutely can remove it by using "Accentless" trait as other species accents do behave like that.

## Media
![img](https://github.com/user-attachments/assets/d64e9259-6756-4224-b886-6aca43d59b0f)
- For the purpose of demonstration, I have changed chance of ending addition to 100%.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- Add: Felinid Accent! Nyaw!
