### PR TITLE
Add group for barricades and barded wire 06 05 2025

### DIFF
--- a/Resources/Locale/en-US/_RMC14/construction/construction-categories.ftl
+++ b/Resources/Locale/en-US/_RMC14/construction/construction-categories.ftl
@@ -1,4 +1,5 @@
 construction-category-cm-all = Усе
+construction-category-cm-barricades = Барикади
 construction-category-cm-structures = Структури
 construction-category-cm-utilities = Додаткове
 construction-category-cm-materials = Матеріали

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/materials.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/materials.yml
@@ -5,7 +5,7 @@
   graph: BarbedWireGraph
   startNode: start
   targetNode: nodeBarbedWire
-  category: construction-category-cm-materials
+  category: construction-category-cm-barricades
   description: Створюйте колючий дріт, щоб прикрасити ваші барикади.
   icon: { sprite: _RMC14/Objects/barbed_wire.rsi, state: barbed_wire }
   objectType: Item

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
@@ -196,7 +196,7 @@
   graph: BarricadeMetalGraph
   startNode: start
   targetNode: nodeMetal
-  category: construction-category-cm-structures
+  category: construction-category-cm-barricades
   description: Барикада із сталі військового зразку.
   objectType: Structure
   placementMode: SnapgridCenter
@@ -215,7 +215,7 @@
   graph: BarricadePlasteelGraph
   startNode: start
   targetNode: nodePlasteel
-  category: construction-category-cm-structures
+  category: construction-category-cm-barricades
   description: Барикада із пласталі військового зразку.
   objectType: Structure
   placementMode: SnapgridCenter
@@ -273,7 +273,7 @@
   startNode: start
   targetNode: nodeTurnstileMed
   category: construction-category-cm-structures
-  description: Огорожа, яка забезпечує порядок і контроль черги морпіхів у медичному відділі. 
+  description: Огорожа, яка забезпечує порядок і контроль черги морпіхів у медичному відділі.
   objectType: Structure
   placementMode: SnapgridCenter
   canBuildInImpassable: false
@@ -310,7 +310,7 @@
   graph: BarricadeMetalDoorGraph
   startNode: start
   targetNode: nodeBarricadeMetalDoor
-  category: construction-category-cm-structures
+  category: construction-category-cm-barricades
   description: Барикада, яку можна скласти, щоб звільнити прохід, або розкласти для обмеження доступу.
   objectType: Structure
   placementMode: SnapgridCenter
@@ -329,7 +329,7 @@
   graph: BarricadePlasteelDoorGraph
   startNode: start
   targetNode: nodeBarricadePlasteelDoor
-  category: construction-category-cm-structures
+  category: construction-category-cm-barricades
   description: Барикада, яку можна скласти, щоб звільнити прохід, або розкласти для обмеження доступу. Виготовлена з загартованої пласталі.
   objectType: Structure
   placementMode: SnapgridCenter

--- a/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Construction/structures.yml
@@ -234,7 +234,7 @@
   graph: BarricadeWoodGraph
   startNode: start
   targetNode: nodeWood
-  category: construction-category-cm-structures
+  category: construction-category-cm-barricades
   description: "Імпровізована дерев'яна барикада."
   objectType: Structure
   placementMode: SnapgridCenter


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added new category in building menu - "Барикади" for all metal, plasteel and even wood barricades alongside with barbed wire for QoL.

## Why / Balance
- On the RMC if you search "bar" you will get barricades AND barbed wire. However, it is not possible with UA localization. Therefore, I added a new category - "Барикади" which contains all of them. 

## Technical details
- Added new line at construction-categories.ftl
- Changed category: construction-category-cm-materials in materials.yml for barbed wire code to category: construction-category-cm-barricades.
- Changed category: construction-category-cm-structures in structures.yml for plasteel, metal and wood barricades for category: construction-category-cm-barricades
- Unfortunately, it is not possible (or am I to stupid to do so) to add two categories but personally I think nobody will notice.

## Media
![img](https://github.com/user-attachments/assets/27f587e3-18aa-4567-8f90-7e4d96ee60bf)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl: tweak: Combined all baricades and barbed wire into one category "Барикади" within building menu!
