### PR TITLE
Translation of the folder resources/locale/en us/launcher/launcher connecting.ftl 07.05.2025

### DIFF
--- a/Resources/Locale/en-US/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/en-US/launcher/launcher-connecting.ftl
@@ -1,15 +1,15 @@
 ### Connecting dialog when you start up the game
 
 connecting-title = Космічна Станція 14
-connecting-exit = Exit
-connecting-retry = Retry
+connecting-exit = Вийти
+connecting-retry = Повторити
 connecting-reconnect = Reconnect
-connecting-copy = Copy Message
+connecting-copy = Скопіювати повідомлення
 connecting-redial = Relaunch
 connecting-redial-wait = Please wait: { TOSTRING($time, "G3") }
-connecting-in-progress = Connecting to server...
-connecting-disconnected = Disconnected from server:
-connecting-tip = Don't die!
+connecting-in-progress = Приєднання до сервера...
+connecting-disconnected = Відключення:
+connecting-tip = Не вмирай!
 connecting-window-tip = Tip { $numberTip }
 connecting-version = ver 0.1
 connecting-fail-reason = Failed to connect to server:
@@ -17,5 +17,5 @@ connecting-fail-reason = Failed to connect to server:
 connecting-state-NotConnecting = Not connecting
 connecting-state-ResolvingHost = Resolving host
 connecting-state-EstablishingConnection = Establishing connection
-connecting-state-Handshake = Handshake
-connecting-state-Connected = Connected
+connecting-state-Handshake = Рукостискання
+connecting-state-Connected = З'єднання

--- a/Resources/Locale/en-US/launcher/launcher-connecting.ftl
+++ b/Resources/Locale/en-US/launcher/launcher-connecting.ftl
@@ -1,6 +1,6 @@
 ### Connecting dialog when you start up the game
 
-connecting-title = Space Station 14
+connecting-title = Космічна Станція 14
 connecting-exit = Exit
 connecting-retry = Retry
 connecting-reconnect = Reconnect


### PR DESCRIPTION
Переклав початкове повідомлення яке з'являється при з'єданні з сервером
![Знімок екрана 2025-05-07 110908](https://github.com/user-attachments/assets/f8d25c17-a503-4142-a9c3-695523f3cb65)
![Знімок екрана 2025-05-07 110922](https://github.com/user-attachments/assets/8b46ecc2-475d-49b9-9f87-71cf32f1da39)
