### PR TITLE
Spec restrictions

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/Squad/specialist.yml
@@ -10,7 +10,7 @@
     sections:
     - name: Weapons Specialist Sets
       takeOne: SquadSpecKit
-      sharedSpecLimit: 2 # 2 as requested until Pyro is added
+      sharedSpecLimit: 1 # 1, бо так вирішили Ми
       entries:
       - id: RMCDemoSpecEquipmentCase
         giveSquadRoleName: rmc-job-name-weapons-specialist-demo

--- a/Resources/Prototypes/_RMC14/Maps/savannah.yml
+++ b/Resources/Prototypes/_RMC14/Maps/savannah.yml
@@ -17,7 +17,7 @@
              #Командування
             CMCommandingOfficer: [1, 1]
             CMExecutiveOfficer: [1, 1]
-            CMStaffOfficer: [4, 4]
+            CMStaffOfficer: [2, 2]
             CMSeniorEnlistedAdvisor: [1, 1]
 
              #ВСП
@@ -50,11 +50,11 @@
 
              #Морпіхи
             CMSquadLeader: [4, 4]
-            CMFireteamLeader: [4, 8]
-            CMSmartGunOperator: [4, 4]
-            CMWeaponsSpecialist: [4, 4]
-            CMCombatTech: [8, 12]
-            CMHospitalCorpsman: [8, 16]
+            CMFireteamLeader: [8, 8]
+            CMSmartGunOperator: [2, 2]
+            CMWeaponsSpecialist: [2, 2]
+            CMCombatTech: [12, 12]
+            CMHospitalCorpsman: [8, 8]
             CMRifleman: [ -1, -1 ]
 
              #Цивільні

--- a/Resources/Prototypes/_RMC14/Maps/savannah.yml
+++ b/Resources/Prototypes/_RMC14/Maps/savannah.yml
@@ -53,8 +53,8 @@
             CMFireteamLeader: [8, 8]
             CMSmartGunOperator: [2, 2]
             CMWeaponsSpecialist: [2, 2]
-            CMCombatTech: [12, 12]
-            CMHospitalCorpsman: [8, 8]
+            CMCombatTech: [8, 8]
+            CMHospitalCorpsman: [12, 12]
             CMRifleman: [ -1, -1 ]
 
              #Цивільні

--- a/Resources/Prototypes/_RMC14/rmc_job_slot_scaling.yml
+++ b/Resources/Prototypes/_RMC14/rmc_job_slot_scaling.yml
@@ -8,61 +8,61 @@
         factor: 40
         c: 1
         min: 3
-        max: 5
+        max: 3
         squad: true
       CMCombatTech:
         factor: 50
         c: 1
         min: 2
-        max: 4
+        max: 2
         squad: true
       CMMilitaryPolice:
         factor: 25
         c: 2
-        min: 4
-        max: 8
+        min: 3
+        max: 3
       CMStaffOfficer:
         factor: 40
         c: 1
         min: 2
-        max: 5
+        max: 2
       CMDoctor:
         factor: 25
         c: 1
         min: 4
-        max: 6
+        max: 4
 #      CMResearcher:
 #        factor: 40
 #        c: 1
 #        min: 2
-#        max: 3
+#        max: 2
 #      CMOrdnanceTech:
 #        factor: 60
 #        c: 1
 #        min: 2
-#        max: 3
+#        max: 2
       CMCargoTech:
         factor: 30
         c: 0
         min: 2
-        max: 3
+        max: 2
       CMIntelOfficer:
         factor: 30
         c: 1
         min: 1
-        max: 3
+        max: 1
       CMWeaponsSpecialist:
         factor: 20
         c: 1
         min: 2
-        max: 4
+        max: 2
       CMSmartGunOperator:
         factor: 20
         c: 1
         min: 2
-        max: 4
+        max: 2
       CMMessTech:
         factor: 70
         c: 1
         min: 1
-        max: 2
+        max: 1


### PR DESCRIPTION
Усування багу лоупопу з більшою кількістю ролей через прибирання зміни кількості ролей в залежності від онлайну. (працювати починають при кількості морпіхів 40-50+, чого у нас нема)

А також зменшення ліміту спеціалістів одного класу з двох до одного за рішенням адміністрації (посилання на адмінчат: https://discord.com/channels/505643295796494346/1259085492830601326/1380876374025306195).
З одного боку додасть ксеноїдам можливостей, коли не буде імба комб з двома підривниками в одному місці, а з іншого додасть морпіхам простору для тактики й стратегії, коли у них обов'язково буде 2 різних спеца.

**Перевірити відсутність багу у грі не вдалося (нажаль, ми не знаємо, як саме його викликати), але наймовірніша першопричина прибрана. А обмеження по спецам точно працює.**