### PR TITLE
Playtimeadd command tweak

### DIFF
--- a/Content.Server/Administration/Commands/PlayTimeCommands.cs
+++ b/Content.Server/Administration/Commands/PlayTimeCommands.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.Host)]
+[AdminCommand(AdminFlags.Moderator)]
 public sealed class PlayTimeAddOverallCommand : IConsoleCommand
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;
@@ -58,7 +58,7 @@ public sealed class PlayTimeAddOverallCommand : IConsoleCommand
     }
 }
 
-[AdminCommand(AdminFlags.Host)]
+[AdminCommand(AdminFlags.Moderator)]
 public sealed class PlayTimeAddRoleCommand : IConsoleCommand
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;


### PR DESCRIPTION
Повернення команд `PlayTimeAddOverall` та `PlayTimeAddRole` в категорію команд модераторів (Moderator) замість групи хоста (Host).

Ця зміна була зроблена локально для білду РМС (у Візардів вони в категорії команд модераторів), але нам подібні обмеження не мають сенсу.